### PR TITLE
fix(investments): restore market-overview table realtime + finalize F…

### DIFF
--- a/salt-microFe/apps/investments/src/component/Investment/MarketPreview/MarketIntelligencePreview/MarketIntelligencePreview.tsx
+++ b/salt-microFe/apps/investments/src/component/Investment/MarketPreview/MarketIntelligencePreview/MarketIntelligencePreview.tsx
@@ -19,9 +19,9 @@ import {
 import { Root } from "@repo/ui/root";
 import { vars } from "@/styles/tokens.css";
 import { Text } from "@repo/ui/text";
-import MarketIntelligenceNewsPreview from "./component/MarketIntelligenceNewsPreview/MarketIntelligenceNewPreview";
+import MarketIntelligenceNewsPreview from "./component/MarketIntelligenceNewsPreview/MarketIntelligenceNewsPreview";
 
-interface MarketIntelligencePreivewProps {
+interface MarketIntelligencePreviewProps {
   symbol: string;
 }
 
@@ -31,7 +31,7 @@ const VISIBLE_ARC = 0.79; // 286도 (전체의 79%)
 const VISIBLE_CIRCUMFERENCE = CIRCUMFERENCE * VISIBLE_ARC;
 
 const MarketIntelligencePreview = React.memo(
-  ({ symbol }: MarketIntelligencePreivewProps) => {
+  ({ symbol }: MarketIntelligencePreviewProps) => {
     const temperatureProgressRef = useRef<HTMLDivElement>(null);
     const progressRef = useRef<SVGCircleElement>(null);
 
@@ -243,4 +243,4 @@ const MarketIntelligencePreview = React.memo(
 
 export default MarketIntelligencePreview;
 
-MarketIntelligencePreview.displayName = "marketIntelligencePreview";
+MarketIntelligencePreview.displayName = "MarketIntelligencePreview";

--- a/salt-microFe/apps/investments/src/component/Investment/MarketPreview/MarketIntelligencePreview/component/MarketIntelligenceNewsPreview/MarketIntelligenceNewsPreview.tsx
+++ b/salt-microFe/apps/investments/src/component/Investment/MarketPreview/MarketIntelligencePreview/component/MarketIntelligenceNewsPreview/MarketIntelligenceNewsPreview.tsx
@@ -50,6 +50,6 @@ const MarketIntelligenceNewsPreview = React.memo(
     );
   },
 );
-MarketIntelligenceNewsPreview.displayName = "marketIntelligenceNewsPreivew";
+MarketIntelligenceNewsPreview.displayName = "MarketIntelligenceNewsPreview";
 
 export default MarketIntelligenceNewsPreview;

--- a/salt-microFe/apps/investments/src/component/Investment/MarketPreview/MarketPreview.tsx
+++ b/salt-microFe/apps/investments/src/component/Investment/MarketPreview/MarketPreview.tsx
@@ -5,7 +5,7 @@ import React, { Suspense } from "react";
 import { ScrollContainer } from "@repo/ui/scrollContainer";
 import MarketPreviewHeader from "./MarketPreviewHeader/MarketPreviewHeader";
 import { Padding } from "@repo/ui/padding";
-import MarketPeviewChart from "./MarketPeviewChart/MarketPeviewChart";
+import MarketPreviewChart from "./MarketPreviewChart/MarketPreviewChart";
 import { Heading } from "@repo/ui/heading";
 import MarketIntelligencePreview from "./MarketIntelligencePreview/MarketIntelligencePreview";
 interface MarketPreviewProps {
@@ -25,7 +25,7 @@ const MarketPreview = ({ selectedSymbolItem, symbol }: MarketPreviewProps) => {
             <Heading level={5} color="tertiary">
               실시간 차트 (5분 봉)
             </Heading>
-            <MarketPeviewChart symbol={symbol} />
+            <MarketPreviewChart symbol={symbol} />
             <MarketIntelligencePreview symbol={symbol} />
           </FlexBox>
         </Suspense>

--- a/salt-microFe/apps/investments/src/component/Investment/MarketPreview/MarketPreviewChart/MarketPreviewChart.tsx
+++ b/salt-microFe/apps/investments/src/component/Investment/MarketPreview/MarketPreviewChart/MarketPreviewChart.tsx
@@ -3,7 +3,7 @@ import { PreviewChart } from "@repo/ui/previewChart";
 import useInvestments from "@/hooks/api/investments/useInvestments";
 import { useMarketPreviewChartRealtime } from "@/hooks/investments/useMarketPreviewChartRealtime";
 
-const MarketPeviewChart = React.memo(
+const MarketPreviewChart = React.memo(
   ({ symbol }: { symbol: string }) => {
     const { investmentsMarketChartPreview } = useInvestments();
     const { data, isLoading, isError } = investmentsMarketChartPreview(symbol);
@@ -18,6 +18,6 @@ const MarketPeviewChart = React.memo(
   },
   (prevProps, nextProps) => prevProps.symbol === nextProps.symbol
 );
-MarketPeviewChart.displayName = "MarketPeviewChart";
+MarketPreviewChart.displayName = "MarketPreviewChart";
 
-export default MarketPeviewChart;
+export default MarketPreviewChart;

--- a/salt-microFe/apps/investments/src/component/Investment/RealtimeInvestment/RealtimeInvestment.tsx
+++ b/salt-microFe/apps/investments/src/component/Investment/RealtimeInvestment/RealtimeInvestment.tsx
@@ -59,8 +59,9 @@ const RealtimeInvestment = () => {
   );
 
   const { data, isLoading, isError } = investmentsMarketOverview(params);
-  useMarketOverviewRealtime(params, handleBlink);
   const items = useMemo(() => data?.items ?? [], [data?.items]);
+  const symbols = useMemo(() => items.map((item) => item.symbol), [items]);
+  useMarketOverviewRealtime(params, symbols, handleBlink);
   const firstSymbol = items[0]?.symbol;
 
   useEffect(() => {

--- a/salt-microFe/apps/investments/src/hooks/investments/useMarketOverviewRealtime.ts
+++ b/salt-microFe/apps/investments/src/hooks/investments/useMarketOverviewRealtime.ts
@@ -10,19 +10,18 @@ import { useEffect } from "react";
 
 export const useMarketOverviewRealtime = (
   params: MarketOverviewParams,
+  symbols: string[],
   onBlink?: (symbol: string) => void
 ) => {
   const queryClient = useQueryClient();
+  // 심볼 목록을 값 기준 키로 만든다.
+  // 첫 마운트엔 데이터가 없어 symbols가 비어 있고, 데이터가 도착해 symbols가
+  // 채워지면 symbolsKey가 바뀌며 effect가 재실행되어 구독이 등록된다.
+  const symbolsKey = symbols.join(",");
   useEffect(() => {
-    // 현재 캐시 가져오기
-    const cache = queryClient.getQueryData<MarketOverviewResponse>([
-      querykeys.MarketOverview,
-      params,
-    ]);
-
-    if (!cache?.items) return;
-    const symbols = cache.items.map((market) => market.symbol);
-    wsClient.subscribePriceBatch(symbols);
+    if (!symbolsKey) return;
+    const targetSymbols = symbolsKey.split(",");
+    wsClient.subscribePriceBatch(targetSymbols);
 
     let frameId: number | null = null;
     const priceQueue: Record<string, { price: number; change24h: number }> = {};
@@ -86,13 +85,16 @@ export const useMarketOverviewRealtime = (
     };
 
     /** 리스너 등록 */
-    symbols.forEach((symbol) => wsClient.addPriceListener(symbol, listener));
+    targetSymbols.forEach((symbol) =>
+      wsClient.addPriceListener(symbol, listener)
+    );
 
     /** 클린업 */
     return () => {
-      symbols.forEach((symbol) =>
+      if (frameId) cancelAnimationFrame(frameId);
+      targetSymbols.forEach((symbol) =>
         wsClient.removePriceListener(symbol, listener)
       );
     };
-  }, [params, queryClient, onBlink]);
+  }, [symbolsKey, params, queryClient, onBlink]);
 };

--- a/salt-microFe/packages/ui/src/PreviewChart/PreviewChart.stories.tsx
+++ b/salt-microFe/packages/ui/src/PreviewChart/PreviewChart.stories.tsx
@@ -1,15 +1,19 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { PreviewChart } from "./PreviewChart";
 
-export default {
+const meta = {
   title: "Charts/PreviewChart",
   component: PreviewChart,
   parameters: {
     layout: "centered",
   },
+  tags: ["autodocs"],
 } satisfies Meta<typeof PreviewChart>;
 
-export const Default: StoryObj<typeof PreviewChart> = {
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
   args: {
     symbol: "BTC",
     timeframe: "5m",

--- a/salt-microFe/packages/ui/src/PreviewChart/PreviewChart.tsx
+++ b/salt-microFe/packages/ui/src/PreviewChart/PreviewChart.tsx
@@ -8,7 +8,7 @@ import React, {
 import { scaleBand, scaleLinear } from "@visx/scale";
 import { Group } from "@visx/group";
 import { Line, Bar } from "@visx/shape";
-import { preivewChartWrapper, tootTipBase } from "./styles/previewChart.css";
+import { previewChartWrapper, tooltipBase } from "./styles/previewChart.css";
 import { vars } from "../styles/tokens.css";
 import { FlexBox } from "../FlexBox/FlexBox";
 import { Margin } from "../Margin/Margin";
@@ -41,7 +41,7 @@ const getMinYAndMaxY = (
     if (c.low < min) min = c.low;
     if (c.high > max) max = c.high;
   }
-  if (min == max) {
+  if (min === max) {
     min = min - 1;
     max = max + 1;
   }
@@ -83,7 +83,9 @@ export const PreviewChart = React.memo(
       [minY, maxY, candleHeight]
     );
 
-    const maxVolume = Math.max(...candles.map((c) => c.volume));
+    const maxVolume = candles.length
+      ? candles.reduce((max, c) => (c.volume > max ? c.volume : max), 0)
+      : 0;
 
     const yVolumeScale = useMemo(
       () =>
@@ -106,13 +108,11 @@ export const PreviewChart = React.memo(
     const formatTime = (timestamp: string) => {
       const date = new Date(timestamp);
 
-      return date
-        .toLocaleTimeString("ko-KR", {
-          hour: "2-digit",
-          minute: "2-digit",
-          hour12: false,
-        })
-        .replace(/:/, ":");
+      return date.toLocaleTimeString("ko-KR", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      });
     };
     const timeLabels: { candle: MarketChartPreviewItem; idx: number }[] =
       useMemo(() => {
@@ -167,8 +167,15 @@ export const PreviewChart = React.memo(
       hoveredXCenter != null && hoveredXCenter < width / 2 ? "right" : "left";
 
     return (
-      <div className={preivewChartWrapper} style={{ width, height }}>
-        <svg ref={svgRef} width={width} height={height}>
+      <div className={previewChartWrapper} style={{ width, height }}>
+        <svg
+          ref={svgRef}
+          width={width}
+          height={height}
+          role="img"
+          aria-label={`${symbol} ${timeframe} 봉 미리보기 차트`}
+        >
+          <title>{`${symbol} ${timeframe} 봉 미리보기 차트`}</title>
           <Group>
             {/* 수평 그리드 라인 (연한 회색) */}
             {gridXYValue.map((v, idx) => {
@@ -271,6 +278,7 @@ export const PreviewChart = React.memo(
                   : x;
               return (
                 <text
+                  key={`time-${idx}`}
                   x={paddedX}
                   y={axisHeight / 2 + 4}
                   textAnchor="middle"
@@ -295,7 +303,7 @@ export const PreviewChart = React.memo(
         {/* Tooltip 카드 (HTML) */}
         {hoveredCandle && hoveredXCenter != null && (
           <div
-            className={tootTipBase}
+            className={tooltipBase}
             style={{
               left: hoveredXCenter,
               top: candleHeight * 0.3,
@@ -367,3 +375,5 @@ export const PreviewChart = React.memo(
     );
   }
 );
+
+PreviewChart.displayName = "PreviewChart";

--- a/salt-microFe/packages/ui/src/PreviewChart/styles/previewChart.css.ts
+++ b/salt-microFe/packages/ui/src/PreviewChart/styles/previewChart.css.ts
@@ -1,7 +1,7 @@
 import { style } from "@vanilla-extract/css";
 import { vars } from "../../styles/tokens.css";
 
-export const preivewChartWrapper = style({
+export const previewChartWrapper = style({
   position: "relative",
   width: 447,
   height: 210,
@@ -9,7 +9,7 @@ export const preivewChartWrapper = style({
   overflow: "hidden",
 });
 
-export const tootTipBase = style({
+export const tooltipBase = style({
   position: "absolute",
   top: 40,
   width: "35%",

--- a/salt-microFe/requirements/reports/checklists/FE-REQ-002.md
+++ b/salt-microFe/requirements/reports/checklists/FE-REQ-002.md
@@ -1,0 +1,70 @@
+---
+id: FE-REQ-002
+spec: ../../specs/done/FE-REQ-002.md
+title: 투자 시장 미리보기 확장 및 차트 디자인시스템 승격 체크리스트
+validated: 2026-05-31
+---
+
+# FE-REQ-002 체크리스트
+
+## 요구사항 검증
+
+| # | 요구사항 | 구현 위치 | 상태 |
+|---|---|---|---|
+| 1 | 순수 차트를 `@repo/ui`의 `PreviewChart`로 승격 | `packages/ui/src/PreviewChart/PreviewChart.tsx` | ✅ |
+| 2 | `./previewChart` 공개 subpath 추가, 앱은 subpath로 import | `packages/ui/package.json`, `apps/investments/.../MarketPreviewChart/MarketPreviewChart.tsx` | ✅ |
+| 3 | `PreviewChart` Storybook story 추가(CSF3 + autodocs) | `packages/ui/src/PreviewChart/PreviewChart.stories.tsx` | ✅ |
+| 4 | SVG 차트에 접근 가능한 label 제공 | `packages/ui/src/PreviewChart/PreviewChart.tsx` (`role="img"`, `aria-label`, `<title>`) | ✅ |
+| 5 | 앱 로컬 차트는 데이터 와이어링만, 시각화는 `PreviewChart`에 위임 | `apps/investments/.../MarketPreview/MarketPreviewChart/MarketPreviewChart.tsx` | ✅ |
+| 6 | 시장 심리/스마트머니/뉴스 인텔리전스 추가 | `apps/investments/.../MarketPreview/MarketIntelligencePreview/MarketIntelligencePreview.tsx` | ✅ |
+| 7 | 뉴스 미리보기/Badge 분리 | `.../MarketIntelligencePreview/component/MarketIntelligenceNewsPreview/MarketIntelligenceNewsPreview.tsx`, `.../Badge/Badge.tsx` | ✅ |
+| 8 | 실시간 캔들 hook 분리(구독/해제 + setQueryData) | `apps/investments/src/hooks/investments/useMarketPreviewChartRealtime.ts` | ✅ |
+| 9 | 애니메이션을 transform / SVG stroke-dashoffset + rAF로 처리 | `MarketIntelligencePreview.tsx` | ✅ |
+| 10 | 탭 상수를 라우트 폴더 밖 `src/constants`로 이동 | `apps/investments/src/constants/investmentTabs.ts` | ✅ |
+| 11 | 무거운 실시간 위젯을 `next/dynamic({ssr:false})` client island로 분리 | `apps/investments/src/pages/investment/index.tsx` | ✅ |
+| 12 | WebSocket 타입 파일명 오타 정리 | `apps/investments/src/libs/webSocketClient/type/webSocketClient.type.ts` | ✅ |
+| 13 | 컴포넌트/파일/디렉터리/`displayName` 오타 정리 | `MarketPreviewChart/`, `MarketIntelligenceNewsPreview.tsx`, `MarketIntelligencePreviewProps` | ✅ (리뷰 단계에서 수정) |
+| 14 | 마켓 오버뷰 테이블 실시간 회귀 수정(cold-cache 구독 누락) | `apps/investments/src/hooks/investments/useMarketOverviewRealtime.ts`, `apps/investments/src/component/Investment/RealtimeInvestment/RealtimeInvestment.tsx` | ✅ (검증 중 발견 후 수정) |
+
+## 리뷰 단계에서 수정한 항목
+
+| 항목 | 수정 전 | 수정 후 | 파일 |
+|---|---|---|---|
+| 디렉터리/컴포넌트명 오타 | `MarketPeviewChart` | `MarketPreviewChart` | `apps/investments/.../MarketPreview/MarketPreviewChart/` |
+| 파일명 오타 | `MarketIntelligenceNewPreview.tsx` | `MarketIntelligenceNewsPreview.tsx` | 뉴스 미리보기 |
+| interface 오타 | `MarketIntelligencePreivewProps` | `MarketIntelligencePreviewProps` | `MarketIntelligencePreview.tsx` |
+| 스타일 export 오타 | `preivewChartWrapper`, `tootTipBase` | `previewChartWrapper`, `tooltipBase` | `previewChart.css.ts` + 사용처 |
+| `displayName` 케이싱/오타 | `"marketIntelligencePreview"`, `"marketIntelligenceNewsPreivew"`, 누락 | PascalCase로 통일, `PreviewChart` 추가 | 각 컴포넌트 |
+| 리스트 `key` 누락 | `<text>` time label에 key 없음(React 경고) | `key={`time-${idx}`}` 추가 | `PreviewChart.tsx` |
+| 미사용 props | `symbol`, `timeframe` 선언만 됨 | SVG 접근성 label로 사용 | `PreviewChart.tsx` |
+| no-op 코드 | `.replace(/:/, ":")` | 제거 | `PreviewChart.tsx` (`formatTime`) |
+| 빈 배열 위험 | `Math.max(...candles.map())` → 빈 배열 시 `-Infinity` | `reduce` + 길이 가드 | `PreviewChart.tsx` (`maxVolume`) |
+| 비교 연산자 | `min == max` | `min === max` | `PreviewChart.tsx` |
+| story 컨벤션 | `tags` 누락, `StoryObj<typeof PreviewChart>` | `tags:["autodocs"]`, `StoryObj<typeof meta>` | `PreviewChart.stories.tsx` |
+| 테이블 실시간 회귀 | cold-cache 첫 진입 시 `getQueryData` 빈값으로 effect bail → 재구독 안 됨(deps에 데이터 없음) | `useMarketOverviewRealtime(params, symbols, onBlink)` + `symbolsKey` 의존, cleanup `cancelAnimationFrame` 추가 | `useMarketOverviewRealtime.ts`, `RealtimeInvestment.tsx` |
+
+## 검증 산출 (2026-05-31 재실행)
+
+```text
+pnpm --filter @repo/message-event-bus check-types   # OK
+pnpm --filter @repo/ui check-types                  # OK
+
+cd apps/shell        && npx tsc --noEmit            # OK (exit 0)
+cd apps/goals        && npx tsc --noEmit            # OK (exit 0)
+cd apps/investments  && npx tsc --noEmit            # OK (exit 0)
+
+pnpm --filter shell        lint                     # OK
+pnpm --filter goals        lint                     # OK
+pnpm --filter investments  lint                     # OK
+
+pnpm --filter goals        build                    # OK
+pnpm --filter investments  build                    # OK
+pnpm --filter shell        build                    # OK
+```
+
+## 참고
+
+- `PreviewChart`(이번 신규 파일)는 `@repo/ui` lint 경고를 새로 만들지 않는다. 리뷰 단계에서 발견된 3개 경고(미사용 `symbol`/`timeframe`, `displayName` 누락)는 수정 완료.
+- `pnpm --filter @repo/ui lint`는 여전히 `--max-warnings 0`을 통과하지 못한다. 남은 23개 경고는 stories/`useDebounce`/`useThrottle`/`Table`/`Tabs` 등 **이번 작업 이전부터 있던** 경고이며 FE-REQ-001 회고에서 이미 별도 정리 대상으로 기록되어 있다(범위 밖).
+- `pnpm --filter shell build`는 remote dev server(goals 3001, investments 3002)가 꺼져 있으면 `goals/AddGoals offline` 등 remote offline 로그를 남기지만 `RemoteBoundary` fallback이 동작해 build는 성공한다.
+- 테이블 실시간 회귀 수정 후 `investments` tsc/lint/build를 재실행해 모두 통과 확인.

--- a/salt-microFe/requirements/reports/retrospects/FE-REQ-002.md
+++ b/salt-microFe/requirements/reports/retrospects/FE-REQ-002.md
@@ -1,0 +1,74 @@
+---
+id: FE-REQ-002
+spec: ../../specs/done/FE-REQ-002.md
+checklist: ../checklists/FE-REQ-002.md
+title: 투자 시장 미리보기 확장 및 차트 디자인시스템 승격 회고
+completed: 2026-05-31
+---
+
+# FE-REQ-002 회고
+
+## 요약
+
+codex 자동화로 `MarketPreview`를 "실시간 캔들 차트 + 시장 인텔리전스(심리/스마트머니/뉴스)"로 확장하고, 순수 차트 렌더링을 `@repo/ui`의 `PreviewChart`로 승격했다. 실시간 캔들 갱신은 `useMarketPreviewChartRealtime` hook으로 분리해 React Query cache를 owner로 두고 `setQueryData`로 갱신한다. 검증(타입/린트/3앱 build)은 모두 통과했고, 리뷰 단계에서 네이밍 오타·미사용 props·누락된 `key`·no-op 코드 등 품질 이슈를 직접 수정했다.
+
+## 변경 내용
+
+- 앱 로컬 `MarketChartPreview`의 시각화 로직을 `packages/ui/src/PreviewChart`로 승격하고 `./previewChart` 공개 subpath와 Storybook story를 추가했다.
+- 앱 로컬 `MarketPreviewChart`는 `useInvestments` + `useMarketPreviewChartRealtime`로 데이터를 모아 `PreviewChart`에 props로만 넘기는 와이어링 컴포넌트로 정리했다.
+- `MarketIntelligencePreview`(심리 온도계, 스마트머니 원형 progress)와 `MarketIntelligenceNewsPreview`/`Badge`를 추가했다. 애니메이션은 `transform`/SVG `stroke-dashoffset` + `requestAnimationFrame`으로 처리한다.
+- `useMarketPreviewChartRealtime`가 `wsClient` 구독/해제와 `setQueryData` 기반 슬라이딩 윈도우 갱신을 담당한다.
+- 탭 상수를 `pages/investment/menu/`에서 `src/constants/investmentTabs.ts`로 이동하고, `RealtimeInvestment`를 `next/dynamic({ssr:false})` client island로 분리했다.
+- WebSocket 타입 파일명 오타(`webSokcetClient` → `webSocketClient`)를 정리했다.
+
+## 리뷰에서 직접 고친 것
+
+- **네이밍 오타 정리**: `MarketPeviewChart`→`MarketPreviewChart`(디렉터리/파일/컴포넌트/displayName), `MarketIntelligenceNewPreview.tsx`→`MarketIntelligenceNewsPreview.tsx`, `MarketIntelligencePreivewProps`→`MarketIntelligencePreviewProps`, css `preivewChartWrapper`/`tootTipBase`→`previewChartWrapper`/`tooltipBase`.
+- **React 경고 제거**: `PreviewChart`의 time label `<text>`에 누락된 `key` 추가.
+- **미사용 props 활용**: `PreviewChart`가 받기만 하고 안 쓰던 `symbol`/`timeframe`을 SVG 접근성 label(`role="img"`, `aria-label`, `<title>`)로 사용 — lint 경고 제거와 a11y 규칙 충족을 동시에 달성.
+- **displayName 정리**: 컴포넌트 displayName을 PascalCase로 통일하고 `PreviewChart`에 추가.
+- **사소한 정리**: `formatTime`의 no-op `.replace(/:/, ":")` 제거, `maxVolume`을 빈 배열에서 `-Infinity`가 나오지 않도록 `reduce`+가드로 변경, `==`→`===`, story를 CSF3 컨벤션(`tags:["autodocs"]`, `StoryObj<typeof meta>`)에 맞춤.
+
+## 실시간 테이블 회귀 (검증 중 발견 후 수정)
+
+마이그레이션 후 "마켓 오버뷰 테이블의 실시간 가격이 새 진입/새로고침에서 안 나온다"는 회귀가 발견됐다. 실시간 차트는 정상이라 소켓 연결 문제로 보였지만, 실제 원인은 다른 곳이었다.
+
+- **증상**: 첫 진입/새로고침 시 테이블만 실시간이 멈춤. 관심종목 탭으로 갔다가 돌아오면 동작. 차트는 영향 없음.
+- **원인**: 마이그레이션에서 `useInvestments`의 `investmentsMarketOverview`가 `useSuspenseQuery` → `useQuery`로 바뀌었다. `useMarketOverviewRealtime` 훅은 "effect가 처음 실행될 때 캐시에 데이터가 이미 있다"는 가정(= suspense가 보장하던 warm cache) 위에 작성돼 있었다. `useQuery`로 바뀌면서 컴포넌트가 로딩 상태로 즉시 마운트되고, 훅 effect가 cold 시점에 `getQueryData`로 `undefined`를 받아 `return`으로 빠진 뒤, 의존성(`[params, queryClient, onBlink]`)이 안 바뀌어 데이터가 도착해도 재실행되지 않아 구독이 영영 등록되지 않았다.
+- **차트가 멀쩡한 이유**: `useMarketPreviewChartRealtime`는 `symbol`에 의존하는데 `selectedSymbol`이 로드 후 `"" → 실제 심볼`로 바뀌며 effect가 재실행돼 재구독된다. 테이블 훅엔 그런 데이터 의존성이 없었다.
+- **해결**: 훅을 다시 suspense에 묶는 대신 데이터(심볼)에 반응하도록 바꿨다. `useMarketOverviewRealtime(params, symbols, onBlink)`로 `symbols`를 받고, `symbolsKey = symbols.join(",")`를 의존성에 넣어 심볼이 채워지는 순간 effect가 재실행돼 구독이 등록된다. cleanup에 `cancelAnimationFrame`도 추가했다. 이로써 cold/warm, SSR/CSR 무관하게 동작하며 SSR 마이그레이션 방향과도 충돌하지 않는다.
+- **성능 메모**: 본 변경은 "더 빠른" 변경이 아니라 "올바른" 변경이다. suspense↔useQuery는 속도가 아니라 렌더 오케스트레이션/SSR 정합성 차이다. 실시간 성능의 실제 핵심(rAF 배치, 변경분만 `setQueryData`, `memoKey` 행 메모이제이션)은 그대로다. 초기 로드 UX/성능을 더 올리려면 SSR prefetch + dehydrate/hydrate가 레버이며, 이는 FE-REQ-001에서 범위 밖으로 둔 별도 작업이다.
+
+## 잘된 점
+
+- 차트 승격으로 "시각화는 디자인 시스템, 데이터/실시간은 앱"이라는 경계가 명확해졌다. 앱은 `@repo/ui/previewChart` subpath로만 소비하고 deep import가 없다.
+- 실시간 갱신을 hook + `setQueryData`로 분리해 트리 전체 refetch 없이 마지막 캔들만 갱신한다. 구독 해제도 cleanup에서 처리된다.
+- 인텔리전스 애니메이션이 layout 비용이 큰 속성을 피하고 rAF + transform/stroke-dashoffset을 사용해 성능 규칙과 맞다.
+- 자동화 산출물이 빌드/타입/린트를 통과하는 상태로 들어와 리뷰가 "검증 추가"가 아니라 "품질 다듬기"에 집중될 수 있었다.
+
+## 아쉬운 점
+
+- 자동화 결과에 네이밍 오타(`Peview`, `Preivew`, `NewPreview`)가 여러 곳 남아 있었다. 빌드는 통과하지만 검색성·일관성을 해쳐 리뷰에서 일괄 정리해야 했다.
+- `PreviewChart`가 `symbol`/`timeframe`을 받지만 시각화에 쓰지 않아 죽은 props 상태였다(접근성 label로 활용해 해소).
+- `MarketIntelligenceNewsPreview`의 뉴스 제목에 overflow 테스트용 placeholder 문자열(`faskdljf...`)이 남아 있다. mock 데이터지만 실데이터 연동 전 정리 대상이다.
+- `PreviewChart`가 `@visx/*` 차트 의존성을 `@repo/ui`로 들였다. 차트 컴포넌트에는 적절하지만, 기본 primitive 번들에 섞이지 않도록 subpath import 경계를 유지해야 한다.
+- `@repo/ui` lint는 기존 경고 23개 때문에 여전히 `--max-warnings 0`을 통과하지 못한다(FE-REQ-001에서 이미 별도 작업으로 식별됨).
+
+## 후속 조치
+
+- `MarketIntelligenceNewsPreview`의 placeholder 텍스트를 실데이터 연동 또는 결정적 mock으로 교체한다(`packages/mocks` 활용 검토).
+- 뉴스/심리/스마트머니 데이터의 BFF 계약이 정해지면 별도 REQ로 API owner와 타입을 정의한다.
+- `@repo/ui` 기존 lint 경고 정리를 FE-REQ-001 후속과 묶어 `pnpm --filter @repo/ui lint`가 통과하도록 한다.
+- 캔들 수가 크게 늘거나 갱신 빈도가 높아지면 `canvas.md` 기준으로 측정 후 Canvas 전환을 검토한다(현재는 SVG로 충분).
+- 초기 로드 UX/성능과 "데이터 도착 후 구독" 경로를 더 개선하려면 MarketOverview를 SSR prefetch + dehydrate/hydrate하는 별도 REQ를 정의한다(query owner/serialization 정책 포함).
+- suspense → useQuery처럼 데이터 준비 타이밍 가정을 바꾸는 마이그레이션은 캐시 타이밍에 의존하는 hook(실시간 구독 등)의 회귀를 유발할 수 있으므로, 해당 hook은 데이터(파생 키)에 명시적으로 의존하도록 작성한다.
+
+## 품질 점수
+
+| 항목 | 점수 (1-5) | 근거 |
+|---|---:|---|
+| 디자인시스템 경계 | 5/5 | 순수 차트를 `@repo/ui` subpath로 승격하고 앱은 데이터 와이어링만 담당, deep import 없음. |
+| 도메인/구조 정리 | 4/5 | 라우트 폴더 상수 이동·컴포넌트 분리는 잘됐으나 자동화 산출물의 네이밍 오타를 후처리해야 했다. |
+| 실시간/성능 | 4/5 | hook + setQueryData + rAF/transform 애니메이션으로 규칙을 지켰다. 검증 중 발견된 테이블 실시간 회귀(suspense 제거로 인한 cold-cache 구독 누락)를 데이터 의존 구독으로 해결. 보관 개수 상한은 슬라이딩 윈도우(고정 길이)에 암묵적으로 의존한다. |
+| 접근성 | 4/5 | 차트에 접근 가능한 label을 추가했으나 인텔리전스 수치의 비색상 보조 표기는 추가 점검 여지가 있다. |
+| 검증 완성도 | 5/5 | event-bus/ui check-types, 3앱 tsc/lint, 3앱 build가 모두 통과한다. |

--- a/salt-microFe/requirements/specs/done/FE-REQ-002.md
+++ b/salt-microFe/requirements/specs/done/FE-REQ-002.md
@@ -1,0 +1,114 @@
+---
+id: FE-REQ-002
+title: 투자 시장 미리보기(MarketPreview) 확장 및 차트 디자인시스템 승격
+priority: high
+labels: [feature, investments, design-system, chart, realtime, domain-architecture]
+created: 2026-05-31
+updated: 2026-05-31
+---
+
+## Summary
+
+`investments` remote의 `MarketPreview`는 기존에 종목 헤더와 단일 차트(`MarketChartPreview`)만 보여줬다. 이번 작업은 미리보기를 "실시간 캔들 차트 + 시장 인텔리전스(심리 온도계 / 스마트머니 / 뉴스)"로 확장한다.
+
+동시에 차트 렌더링 로직을 앱 로컬 컴포넌트에서 `@repo/ui`의 재사용 차트 컴포넌트(`PreviewChart`)로 승격한다. 앱 로컬 컴포넌트는 데이터 패칭/실시간 구독만 담당하고, 순수 차트 시각화는 디자인 시스템이 소유한다. 라우트 폴더 안에 있던 상수도 앱 `constants`로 이동해 도메인 아키텍처 규칙에 맞춘다.
+
+이 요구사항은 `salt-microFe/**` 범위에만 적용한다. `bff/**`, `salt-server/**` 계약은 변경하지 않는다.
+
+## Research Notes
+
+- `React.memo`로 감싼 함수형 컴포넌트는 `displayName`을 명시하지 않으면 DevTools/lint에서 익명으로 잡힌다. memo 비교 함수는 props 동등성만 판단하고 부수효과를 가지면 안 된다. 출처: [React memo](https://react.dev/reference/react/memo)
+- 차트는 DOM/SVG로 그릴 때 노드 수와 reconciliation 비용이 병목이 될 수 있다. 미리보기 수준(수십 개 캔들)은 SVG로 충분하고, 수천 개 이상/고빈도 갱신에서만 Canvas를 검토한다. 출처: 레포 규칙 `.claude/rules/canvas.md`
+- 차트/canvas는 색상만으로 정보를 전달하지 않고 외부에 요약 텍스트 또는 접근 가능한 label을 제공해야 한다. SVG에는 `role="img"` + `aria-label` 또는 `<title>`을 둘 수 있다. 출처: [MDN SVG title](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title), 레포 규칙 `.claude/rules/a11y-policy.md`
+- 실시간 데이터는 React Query cache를 owner로 두고 `setQueryData`로 갱신하면 컴포넌트 트리 전체를 다시 fetch하지 않고 최신 캔들만 반영할 수 있다. streaming 데이터는 보관 개수 상한과 슬라이딩 윈도우를 둔다. 출처: [TanStack Query setQueryData](https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientsetquerydata), 레포 규칙 `.claude/rules/state-convention.md`, `.claude/rules/performance.md`
+- `requestAnimationFrame` 기반 애니메이션은 `transform`/`opacity`/SVG `stroke-dashoffset`처럼 layout을 유발하지 않는 속성에 한정해야 paint/layout 비용을 줄일 수 있다. 출처: 레포 규칙 `.claude/rules/performance.md`
+- 두 개 이상 앱에서 재사용될 수 있는 순수 UI는 `packages/ui`로 승격하고 공개 `exports` subpath와 Storybook story를 함께 추가한다. 앱은 `packages/ui/src/**` 내부 파일을 deep import하지 않는다. 출처: 레포 규칙 `.claude/rules/design-system.md`, `packages/ui/CLAUDE.md`
+
+## Current Findings (작업 전 상태)
+
+- `apps/investments/.../MarketPreview/MarketChartPreview/MarketChartPreview.tsx`가 데이터 패칭과 차트 렌더링을 한 컴포넌트에서 모두 담당했다.
+- 시장 미리보기에 심리/스마트머니/뉴스 같은 인텔리전스 영역이 없었다.
+- 실시간 캔들 갱신 로직이 정리된 hook으로 분리되어 있지 않았다.
+- 투자 탭 상수(`tabs`)가 라우트 폴더 `pages/investment/menu/investmentTabs.ts`에 있어 "route 파일/폴더에 상수 금지" 도메인 규칙과 어긋났다.
+- WebSocket 타입 파일명이 `webSokcetClient.type.ts`로 오타가 있었다.
+
+## Requirements
+
+### 1. 차트 디자인시스템 승격
+
+- 순수 차트 시각화 컴포넌트를 `packages/ui`의 `PreviewChart`로 승격한다.
+- `packages/ui/package.json` `exports`에 `./previewChart` subpath를 추가하고, 앱은 그 subpath로만 import한다(`@repo/ui/src/**` deep import 금지).
+- `PreviewChart`는 앱 route/store/API를 import하지 않는 순수 UI여야 한다. 데이터는 props(`data`)로만 받는다.
+- 새 재사용 컴포넌트이므로 Storybook story를 추가한다(CSF3, `tags: ["autodocs"]`, 결정적 mock data).
+- SVG 차트에는 접근 가능한 label(`role="img"` + `aria-label` 또는 `<title>`)을 제공한다.
+
+### 2. MarketPreview 데이터 와이어링 분리
+
+- 앱 로컬 차트 컴포넌트(`MarketPreviewChart`)는 데이터 패칭(`useInvestments`)과 실시간 구독만 담당하고, 시각화는 `PreviewChart`에 위임한다.
+- 로딩/에러/빈 데이터 상태에서는 차트 대신 렌더를 중단하거나 fallback을 둔다.
+- `MarketPreview`는 헤더, 실시간 차트, 시장 인텔리전스를 조합하는 얇은 조합 컴포넌트로 유지한다.
+
+### 3. 시장 인텔리전스 미리보기
+
+- `MarketIntelligencePreview`에 시장 심리 온도계, 스마트머니 추적, 뉴스 미리보기를 구성한다.
+- 심리 온도계와 스마트머니 원형 progress 애니메이션은 layout을 유발하지 않는 속성(`transform`, SVG `stroke-dashoffset`)과 `requestAnimationFrame`으로 처리한다.
+- 데이터가 없거나 에러일 때 안전하게 렌더를 중단한다(`data?.` optional 접근, 기본값 사용).
+- 뉴스 항목은 `MarketIntelligenceNewsPreview`와 `Badge`로 분리한다.
+
+### 4. 실시간 캔들 hook
+
+- 실시간 캔들 갱신을 `useMarketPreviewChartRealtime` hook으로 분리한다.
+- hook은 `wsClient.subscribeCandle`로 구독하고 unmount 시 반드시 `unsubscribeCandle`로 해제한다.
+- 갱신은 React Query `setQueryData`로 해당 query key의 캔들 배열만 변경한다(같은 timestamp면 마지막 캔들 교체, 아니면 슬라이딩 윈도우로 append).
+- 다른 symbol/timeframe 이벤트는 무시한다.
+
+### 5. 구조/상수 정리
+
+- 라우트 폴더의 탭 상수를 `apps/investments/src/constants/investmentTabs.ts`로 이동한다.
+- 컴포넌트/파일/디렉터리/타입/`displayName` 네이밍은 PascalCase와 의미 기반 규칙을 따른다(오타 금지).
+- WebSocket 타입 파일명 오타(`webSokcetClient.type.ts` → `webSocketClient.type.ts`)를 바로잡는다.
+- 무거운 browser-only 실시간 위젯은 `next/dynamic({ ssr:false })` client island로 분리한다.
+
+## 구현 계획 (Plan)
+
+1. **승격**: `MarketChartPreview` 시각화 로직을 `packages/ui/src/PreviewChart`로 추출 → `exports`에 `./previewChart` 추가 → Storybook story 작성.
+2. **와이어링**: `MarketPreviewChart`(앱 로컬)에서 `useInvestments` + `useMarketPreviewChartRealtime`로 데이터를 모아 `PreviewChart`에 props로 전달.
+3. **실시간 hook**: `useMarketPreviewChartRealtime` 작성 → `wsClient` 구독/해제 + `setQueryData` 캔들 갱신.
+4. **인텔리전스**: `MarketIntelligencePreview`(심리/스마트머니) + `MarketIntelligenceNewsPreview`/`Badge` 작성, rAF 기반 애니메이션.
+5. **조합**: `MarketPreview`에서 헤더 + 차트 + 인텔리전스를 `Suspense`로 조합.
+6. **정리**: 탭 상수 이동, 파일/타입명 오타 정리, `RealtimeInvestment` client island화.
+7. **검증**: `@repo/ui`/`@repo/message-event-bus` check-types → 3앱 tsc/lint → 3앱 build(goals→investments→shell) → 결과를 체크리스트에 기록.
+8. **회귀 수정**: 검증 중 발견된 테이블 실시간 회귀(suspense 제거로 인한 cold-cache 구독 누락)를 `useMarketOverviewRealtime`이 `symbols`(파생 키)에 의존하도록 바꿔 해결하고 cleanup에 `cancelAnimationFrame`을 추가.
+
+## Acceptance Criteria
+
+- `PreviewChart`가 `@repo/ui`에 있고 `./previewChart` subpath로 export되며 앱이 그 subpath로 import한다.
+- `PreviewChart`가 앱 route/store/API를 import하지 않는다.
+- `PreviewChart`에 Storybook story가 있고 SVG에 접근 가능한 label이 있다.
+- 앱 로컬 `MarketPreviewChart`는 데이터 와이어링만 하고 시각화는 `PreviewChart`에 위임한다.
+- `MarketIntelligencePreview`가 심리/스마트머니/뉴스를 렌더하고 데이터 부재 시 안전하게 중단한다.
+- `useMarketPreviewChartRealtime`가 구독을 등록/해제하고 `setQueryData`로 캔들만 갱신한다.
+- 탭 상수가 라우트 폴더 밖 `src/constants`에 있다.
+- 컴포넌트/파일/디렉터리/`displayName` 오타가 없다.
+- `pnpm --filter @repo/ui check-types`, `pnpm --filter @repo/message-event-bus check-types`가 통과한다.
+- `shell`, `goals`, `investments`의 `tsc --noEmit`과 `lint`가 통과한다.
+- `goals`, `investments`, `shell` build가 모두 성공한다.
+- 신규 파일(`PreviewChart`)이 `@repo/ui` lint 경고를 새로 만들지 않는다.
+
+## Out Of Scope
+
+- `bff`/backend API 계약 변경.
+- Canvas/OffscreenCanvas 차트 렌더링 전환(측정 전 도입 금지).
+- React Query SSR prefetch/dehydrate/hydrate.
+- `@repo/ui` 기존(이번 작업 이전부터 있던) Storybook/util lint 경고 일괄 정리.
+- 뉴스/인텔리전스 실데이터 연동(현재 mock/preview 데이터 기준).
+
+## Changelog
+
+- 2026-05-31: codex 자동화로 구현된 MarketPreview 확장 + PreviewChart 디자인시스템 승격 작업을 요구사항으로 문서화했다.
+- 2026-05-31: 검증/리뷰 과정에서 발견한 네이밍 오타, 누락된 `key`, 미사용 props, displayName 누락, no-op 코드를 수정 항목으로 반영했다(상세는 회고 참조).
+- 2026-05-31: 마이그레이션(useSuspenseQuery → useQuery)으로 발생한 마켓 오버뷰 테이블 실시간 회귀를 수정했다. `useMarketOverviewRealtime`을 `symbols` 의존으로 바꿔 cold-cache 첫 진입/새로고침에서도 구독되도록 했다. 연관 커밋은 `refactor/microfrontend-build` 브랜치의 본 작업 커밋에 포함된다.
+
+## Status
+
+- done (검증 완료: 3앱 tsc/lint/build 통과). 본 spec은 `requirements/specs/done/`에 위치한다.


### PR DESCRIPTION
…E-REQ-002

마이그레이션(useSuspenseQuery → useQuery)으로 깨진 마켓 오버뷰 테이블 실시간 회귀를 수정한다. useMarketOverviewRealtime이 캐시 warm 상태를 암묵적으로 가정해 첫 진입/새로고침(cold cache)에서 구독이 등록되지 않던 문제를, symbols(파생 키) 의존으로 바꿔 데이터 도착 시 재구독되도록 한다. cleanup에 cancelAnimationFrame 추가.

함께 PreviewChart 디자인시스템 승격 리뷰에서 발견한 품질 이슈를 정리한다:
- 네이밍 오타 정리: MarketPeviewChart→MarketPreviewChart, MarketIntelligenceNewPreview→ MarketIntelligenceNewsPreview, MarketIntelligencePreivewProps, preivewChartWrapper/tootTipBase
- PreviewChart: <text> key 누락 수정, 미사용 symbol/timeframe을 SVG 접근성 label로 활용, displayName 추가, no-op replace 제거, maxVolume 빈배열 가드, story CSF3 컨벤션 정리

FE-REQ-002 문서(spec/checklist/retrospect)를 done으로 정리하고 회귀 분석과 Plan/Changelog를 반영한다.

검증: investments tsc/lint/build, @repo/ui·@repo/message-event-bus check-types 통과.